### PR TITLE
Expand domain of the `classes` macro

### DIFF
--- a/stylance/tests/test_classes.rs
+++ b/stylance/tests/test_classes.rs
@@ -1,23 +1,38 @@
 #[test]
 fn test_join_classes() {
-    use stylance::JoinClasses;
+    use stylance::{JoinClasses, NormalizedClass};
+
     assert_eq!(
-        (
-            "one",
-            Some("two"),
-            false.then_some("three"),
-            true.then_some("four"),
-            &String::from("five"),
-            Some(&String::from("six")),
-            &("seven", "eight").join_classes()
-        )
-            .join_classes(),
+        ([
+            Into::<NormalizedClass>::into("one"),
+            Some("two").into(),
+            false.then_some("three").into(),
+            true.then_some("four").into(),
+            (&String::from("five")).into(),
+            Some(&String::from("six")).into(),
+            (&(&["seven".into(), "eight".into()]).join_classes()).into(),
+        ])
+        .join_classes(),
         "one two four five six seven eight"
     );
 }
 
 #[test]
-fn test_classes_macro() {
+fn test_classes_macro_none() {
+    use stylance::classes;
+    assert_eq!(classes!(), "");
+}
+
+#[test]
+fn test_classes_macro_one() {
+    use stylance::classes;
+    assert_eq!(classes!("one"), "one");
+    assert_eq!(classes!(Some("one")), "one");
+    assert_eq!(classes!(false.then_some("one")), "");
+}
+
+#[test]
+fn test_classes_macro_many() {
     use stylance::classes;
     assert_eq!(
         classes!(


### PR DESCRIPTION
I attempted to make the `classes!` macro work for 0, 1 and n > 17 class names. I assume that would be an improvement.

Although I succeeded in making the macro work in a backwards-compatible way, I could not achieve the same with regards to the method-calling / not-macro API.

What I did was: instead of having the macro produce tuples of varieties of `&str` and `Option<&str>`, of which each size between [2, 17] implements its own trait to become convertible to `NormalizeOptionStr`, then actually converting them to `NormalizeOptionStr` and making an array with the results, to then iterate over it, skip the `None`s and finally create the `String`; I, instead, made the macro produce an array of `NormalizeOptionStr` right away. Then, instead of the individual trait implementations, I wrote a general one for every type `T` implementing `AsRef<[NormalizeOptionStr<'a>]>`. This includes every array whose element type is `NormalizeOptionStr<'a>`, regardless of size, as well as slices. Then the array is iterated over, the `None`s are skipped and the `String` is produced.

Because the array elements must now be `NormalizeOptionStr` in order for the array to have access to the `.join_classes()` method, its type will, I think, not be able to be inferred without mention of the symbol `NormalizeOptionStr`, so I pulled it out of the `mod internal` block and gave it a new name, which I think is cleaner: `NormalizedClass`.

My attempts at making the original `.join_classes()` API backwards-compatible, which failed:

1. Simply letting the tuple implementations in. Fails with `` conflicting implementation for `(_, _)` ``. `` upstream crates may add a new impl of trait `std::convert::AsRef<[NormalizedClass<'_>]>` for type `(_, _)` in future versions ``;
2. Implementing `From<$tuple>` for something `AsRef<[NormalizedClass<'a>]>`, or the corresponding `Into` directly. Fails with `only traits defined in the current crate can be implemented for types defined outside of the crate`. 