### PR TITLE
fix: support symlinked folders in stylance config

### DIFF
--- a/internal/stylance-core/src/lib.rs
+++ b/internal/stylance-core/src/lib.rs
@@ -105,9 +105,32 @@ pub fn load_config(manifest_dir: &Path) -> anyhow::Result<Config> {
     Ok(config)
 }
 
+/// Normalize a path by resolving `.` and `..` components and making it
+/// absolute, without following symlinks. This preserves logical paths through
+/// symlinked directories.
+fn normalize_path(path: &Path) -> anyhow::Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+
+    let mut components = Vec::new();
+    for component in absolute.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                components.pop();
+            }
+            std::path::Component::CurDir => {}
+            other => components.push(other),
+        }
+    }
+    Ok(components.iter().collect())
+}
+
 fn normalized_relative_path(base: &Path, subpath: &Path) -> anyhow::Result<String> {
-    let base = base.canonicalize()?;
-    let subpath = subpath.canonicalize()?;
+    let base = normalize_path(base)?;
+    let subpath = normalize_path(subpath)?;
 
     let relative_path_str: String = subpath
         .strip_prefix(base)

--- a/stylance-cli/src/lib.rs
+++ b/stylance-cli/src/lib.rs
@@ -160,3 +160,44 @@ pub fn run_silent(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stylance_core::Config;
+
+    #[cfg(unix)]
+    #[test]
+    fn test_symlinked_folder() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir()
+            .join(format!("stylance_test_{}", std::process::id()));
+        let manifest_dir = base.join("my_app");
+        let external_dir = base.join("external");
+
+        fs::create_dir_all(&manifest_dir).unwrap();
+        fs::create_dir_all(&external_dir).unwrap();
+
+        fs::write(
+            external_dir.join("style.module.css"),
+            ".myClass { color: red; }",
+        )
+        .unwrap();
+
+        // Create symlink: my_app/views -> ../external
+        symlink(&external_dir, manifest_dir.join("views")).unwrap();
+
+        let config = Config {
+            output_file: Some(base.join("out.css")),
+            folders: vec![std::path::PathBuf::from("./views/")],
+            ..Config::default()
+        };
+
+        let result = run_silent(&manifest_dir, &config, |_| {});
+
+        fs::remove_dir_all(&base).unwrap();
+
+        result.expect("run_silent should succeed with symlinked folder");
+    }
+}

--- a/stylance-cli/src/lib.rs
+++ b/stylance-cli/src/lib.rs
@@ -194,10 +194,23 @@ mod tests {
             ..Config::default()
         };
 
-        let result = run_silent(&manifest_dir, &config, |_| {});
+        run_silent(&manifest_dir, &config, |_| {})
+            .expect("run_silent should succeed with symlinked folder");
+
+        let output = fs::read_to_string(base.join("out.css"))
+            .expect("output file should exist");
 
         fs::remove_dir_all(&base).unwrap();
 
-        result.expect("run_silent should succeed with symlinked folder");
+        // Class name should be scoped: .myClass-<hash>
+        assert!(
+            output.contains(".myClass-"),
+            "output should contain scoped class name, got: {output}"
+        );
+        // CSS body should be preserved
+        assert!(
+            output.contains("color: red"),
+            "output should contain original CSS body, got: {output}"
+        );
     }
 }


### PR DESCRIPTION
## Problem

When a folder listed in `[package.metadata.stylance].folders` is a symlink pointing outside the crate root, stylance crashes:

```
Error: css file should be inside manifest_dir

Caused by:
    prefix not found
```

This happens because `normalized_relative_path` calls `std::fs::canonicalize()` on both the manifest dir and the CSS file path. Canonicalization resolves symlinks to their real absolute path, so the CSS file appears to live outside `manifest_dir`, and the `strip_prefix` check fails.

## Why this is a bug, not a feature

The `manifest_dir` prefix check exists to prevent *accidental* path escapes (e.g. a typo like `../../etc/`). It was never meant to reject symlinks — symlinks in `folders` are an explicit, intentional choice by the developer. There is no scenario where someone deliberately creates a symlink in their configured folder and expects stylance to reject it.

Additionally, the current behavior is a hard crash with no workaround (stylance explicitly rejects `../../` paths, making a symlink the *only* option for bridging crates in a workspace restructuring).

## Common use case this fixes

A workspace where crates are restructured from nested to shared:

```toml
# bins/my_app/Cargo.toml
[package.metadata.stylance]
folders = ["./src/", "./views/"]
```

```
my_workspace/
  bins/my_app/
    Cargo.toml
    src/
    views/        # symlink → ../../crates/views/
  crates/views/
    panel.module.css
```

## Fix

Replace `canonicalize()` with a `normalize_path` helper that makes paths absolute and resolves `.`/`..` components **without following symlinks**. This preserves the logical path as traversed through the filesystem, so `strip_prefix` succeeds.

The safety guarantee of the prefix check is maintained: `..` components are still resolved before the check, so accidental path escapes are still caught.

## Notes

- No behaviour change for non-symlinked folders — for regular directories, logical normalization and canonicalization produce the same result.
- Symlink cycles are safe: WalkDir uses `follow_links(false)` (default), so symlinks encountered *during* traversal are not descended into. Only the root configured folder itself is followed by the OS.
- Hash stability is preserved: hashes are computed from the relative path after `strip_prefix`, which is the logical path through the symlink — stable and deterministic for a given workspace layout.
- No new dependencies introduced.
