### PR TITLE
feat: shared output_file support and incremental watch rebuilds

### DIFF
--- a/internal/stylance-core/src/lib.rs
+++ b/internal/stylance-core/src/lib.rs
@@ -279,6 +279,7 @@ pub fn resolve_hash_root(manifest_dir: &Path, config: &Config) -> PathBuf {
     }
 }
 
+#[derive(Clone)]
 pub struct ModifyCssResult {
     pub path: PathBuf,
     pub normalized_path_str: String,

--- a/stylance-cli/src/lib.rs
+++ b/stylance-cli/src/lib.rs
@@ -1,14 +1,14 @@
 use std::{
     borrow::Cow,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs::{self, File},
     io::{BufWriter, Write},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use anyhow::bail;
 pub use stylance_core::Config;
-use stylance_core::ModifyCssResult;
+pub use stylance_core::ModifyCssResult;
 use walkdir::WalkDir;
 
 pub fn run(manifest_dir: &Path, config: &Config) -> anyhow::Result<()> {
@@ -21,8 +21,19 @@ pub fn run(manifest_dir: &Path, config: &Config) -> anyhow::Result<()> {
 pub fn run_silent(
     manifest_dir: &Path,
     config: &Config,
-    mut file_visit_callback: impl FnMut(&Path),
+    file_visit_callback: impl FnMut(&Path),
 ) -> anyhow::Result<()> {
+    let results = build_crate(manifest_dir, config, file_visit_callback)?;
+    write_output(config, &results)
+}
+
+/// Build a single crate: discover CSS files, transform them, check for hash
+/// collisions, and return the sorted results without writing anything to disk.
+pub fn build_crate(
+    manifest_dir: &Path,
+    config: &Config,
+    mut file_visit_callback: impl FnMut(&Path),
+) -> anyhow::Result<Vec<ModifyCssResult>> {
     let hash_root = stylance_core::resolve_hash_root(manifest_dir, config);
     let mut modified_css_files = Vec::new();
 
@@ -50,120 +61,266 @@ pub fn run_silent(
         }
     }
 
-    {
-        // Verify that there are no hash collisions
-        let mut map = HashMap::new();
-        for file in modified_css_files.iter() {
-            if let Some(previous_file) = map.insert(&file.hash, file) {
-                bail!(
-                    "The following files had a hash collision:\n{}\n{}\nConsider increasing the hash_len setting.",
-                    file.path.to_string_lossy(),
-                    previous_file.path.to_string_lossy()
-                );
-            }
+    check_hash_collisions(&modified_css_files)?;
+    sort_results(&mut modified_css_files);
+
+    Ok(modified_css_files)
+}
+
+fn check_hash_collisions(files: &[ModifyCssResult]) -> anyhow::Result<()> {
+    let mut map = HashMap::new();
+    for file in files.iter() {
+        if let Some(previous_file) = map.insert(&file.hash, file) {
+            bail!(
+                "The following files had a hash collision:\n{}\n{}\nConsider increasing the hash_len setting.",
+                file.path.to_string_lossy(),
+                previous_file.path.to_string_lossy()
+            );
         }
     }
+    Ok(())
+}
 
-    {
-        // sort by (filename, path)
-        fn key(a: &ModifyCssResult) -> (&std::ffi::OsStr, &String) {
-            (
-                a.path.file_name().expect("should be a file"),
-                &a.normalized_path_str,
-            )
-        }
-        modified_css_files.sort_unstable_by(|a, b| key(a).cmp(&key(b)));
+fn sort_results(files: &mut [ModifyCssResult]) {
+    fn key(a: &ModifyCssResult) -> (&std::ffi::OsStr, &String) {
+        (
+            a.path.file_name().expect("should be a file"),
+            &a.normalized_path_str,
+        )
     }
+    files.sort_unstable_by(|a, b| key(a).cmp(&key(b)));
+}
 
+/// Write build results to disk for a single crate's config.
+pub fn write_output(config: &Config, results: &[ModifyCssResult]) -> anyhow::Result<()> {
     if let Some(output_file) = &config.output_file {
-        if let Some(parent) = output_file.parent() {
-            fs::create_dir_all(parent)?;
+        write_output_file(output_file, config.scss_prelude.as_deref(), &[results])?;
+    }
+
+    if let Some(output_dir) = &config.output_dir {
+        write_output_dir(output_dir, config.scss_prelude.as_deref(), results)?;
+    }
+
+    Ok(())
+}
+
+/// Build the content string for a concatenated output file without writing it.
+pub fn build_output_file_content(
+    output_file: &Path,
+    scss_prelude: Option<&str>,
+    crate_results: &[&[ModifyCssResult]],
+) -> String {
+    let mut content = String::new();
+
+    if let Some(scss_prelude) = scss_prelude {
+        if output_file
+            .extension()
+            .filter(|ext| ext.to_string_lossy() == "scss")
+            .is_some()
+        {
+            content.push_str(scss_prelude);
+            content.push_str("\n\n");
         }
+    }
 
-        let mut file = BufWriter::new(File::create(output_file)?);
+    let all_contents: Vec<&str> = crate_results
+        .iter()
+        .flat_map(|results| results.iter().map(|r| r.contents.as_ref()))
+        .collect();
 
-        if let Some(scss_prelude) = &config.scss_prelude {
-            if output_file
-                .extension()
-                .filter(|ext| ext.to_string_lossy() == "scss")
-                .is_some()
-            {
+    content.push_str(&all_contents.join("\n\n"));
+    content
+}
+
+/// Write one or more crates' results into a single concatenated CSS file.
+/// Each slice in `crate_results` is one crate's sorted output; they are
+/// concatenated in the order given.
+pub fn write_output_file(
+    output_file: &Path,
+    scss_prelude: Option<&str>,
+    crate_results: &[&[ModifyCssResult]],
+) -> anyhow::Result<()> {
+    if let Some(parent) = output_file.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let content = build_output_file_content(output_file, scss_prelude, crate_results);
+    let mut file = BufWriter::new(File::create(output_file)?);
+    file.write_all(content.as_bytes())?;
+
+    Ok(())
+}
+
+pub fn write_output_dir(
+    output_dir: &Path,
+    scss_prelude: Option<&str>,
+    results: &[ModifyCssResult],
+) -> anyhow::Result<()> {
+    let output_dir = output_dir.join("stylance");
+    fs::create_dir_all(&output_dir)?;
+
+    let entries = fs::read_dir(&output_dir)?;
+
+    for entry in entries {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+
+        if file_type.is_file() {
+            fs::remove_file(entry.path())?;
+        }
+    }
+
+    let mut new_files = Vec::new();
+    for modified_css in results {
+        let extension = modified_css
+            .path
+            .extension()
+            .map(|e| e.to_string_lossy())
+            .filter(|e| e == "css")
+            .unwrap_or(Cow::from("scss"));
+
+        let new_file_name = format!(
+            "{}-{}.{extension}",
+            modified_css
+                .path
+                .file_stem()
+                .expect("This path should be a file")
+                .to_string_lossy(),
+            modified_css.hash
+        );
+
+        new_files.push(new_file_name.clone());
+
+        let file_path = output_dir.join(new_file_name);
+        let mut file = BufWriter::new(File::create(file_path)?);
+
+        if let Some(scss_prelude) = scss_prelude {
+            if extension == "scss" {
                 file.write_all(scss_prelude.as_bytes())?;
                 file.write_all(b"\n\n")?;
             }
         }
 
-        file.write_all(
-            modified_css_files
-                .iter()
-                .map(|r| r.contents.as_ref())
-                .collect::<Vec<_>>()
-                .join("\n\n")
-                .as_bytes(),
-        )?;
+        file.write_all(modified_css.contents.as_bytes())?;
     }
 
-    if let Some(output_dir) = &config.output_dir {
-        let output_dir = output_dir.join("stylance");
-        fs::create_dir_all(&output_dir)?;
-
-        let entries = fs::read_dir(&output_dir)?;
-
-        for entry in entries {
-            let entry = entry?;
-            let file_type = entry.file_type()?;
-
-            if file_type.is_file() {
-                fs::remove_file(entry.path())?;
-            }
-        }
-
-        let mut new_files = Vec::new();
-        for modified_css in modified_css_files {
-            let extension = modified_css
-                .path
-                .extension()
-                .map(|e| e.to_string_lossy())
-                .filter(|e| e == "css")
-                .unwrap_or(Cow::from("scss"));
-
-            let new_file_name = format!(
-                "{}-{}.{extension}",
-                modified_css
-                    .path
-                    .file_stem()
-                    .expect("This path should be a file")
-                    .to_string_lossy(),
-                modified_css.hash
-            );
-
-            new_files.push(new_file_name.clone());
-
-            let file_path = output_dir.join(new_file_name);
-            let mut file = BufWriter::new(File::create(file_path)?);
-
-            if let Some(scss_prelude) = &config.scss_prelude {
-                if extension == "scss" {
-                    file.write_all(scss_prelude.as_bytes())?;
-                    file.write_all(b"\n\n")?;
-                }
-            }
-
-            file.write_all(modified_css.contents.as_bytes())?;
-        }
-
-        let mut file = File::create(output_dir.join("_index.scss"))?;
-        file.write_all(
-            new_files
-                .iter()
-                .map(|f| format!("@use \"{f}\";\n"))
-                .collect::<Vec<_>>()
-                .join("")
-                .as_bytes(),
-        )?;
-    }
+    let mut file = File::create(output_dir.join("_index.scss"))?;
+    file.write_all(
+        new_files
+            .iter()
+            .map(|f| format!("@use \"{f}\";\n"))
+            .collect::<Vec<_>>()
+            .join("")
+            .as_bytes(),
+    )?;
 
     Ok(())
+}
+
+/// Stateful per-crate builder that caches per-file results.
+/// On incremental rebuilds only the changed files are re-processed.
+pub struct CrateBuilder {
+    manifest_dir: PathBuf,
+    config: Config,
+    hash_root: PathBuf,
+    files: HashMap<PathBuf, ModifyCssResult>,
+}
+
+impl CrateBuilder {
+    pub fn new(manifest_dir: PathBuf, config: Config) -> Self {
+        let hash_root = stylance_core::resolve_hash_root(&manifest_dir, &config);
+        Self {
+            manifest_dir,
+            config,
+            hash_root,
+            files: HashMap::new(),
+        }
+    }
+
+    /// Create a builder pre-populated with existing build results.
+    pub fn from_results(
+        manifest_dir: PathBuf,
+        config: Config,
+        results: Vec<ModifyCssResult>,
+    ) -> Self {
+        let hash_root = stylance_core::resolve_hash_root(&manifest_dir, &config);
+        let files = results.into_iter().map(|r| (r.path.clone(), r)).collect();
+        Self {
+            manifest_dir,
+            config,
+            hash_root,
+            files,
+        }
+    }
+
+    /// Full rebuild: clear cache and re-process all CSS files in the crate.
+    pub fn build_all(&mut self) -> anyhow::Result<()> {
+        self.files.clear();
+
+        for folder in self.config.folders() {
+            for (entry, meta) in WalkDir::new(self.manifest_dir.join(folder))
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter_map(|entry| entry.metadata().ok().map(|meta| (entry, meta)))
+            {
+                if meta.is_file() {
+                    let path_str = entry.path().to_string_lossy();
+                    if self
+                        .config
+                        .extensions()
+                        .iter()
+                        .any(|ext| path_str.ends_with(ext))
+                    {
+                        let result = stylance_core::load_and_modify_css(
+                            &self.hash_root,
+                            entry.path(),
+                            &self.config,
+                        )?;
+                        self.files.insert(entry.path().to_path_buf(), result);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Incremental rebuild: only re-process the files that changed.
+    pub fn rebuild_changed(&mut self, changed: &HashSet<PathBuf>) -> anyhow::Result<()> {
+        for path in changed {
+            if path.exists() {
+                let result =
+                    stylance_core::load_and_modify_css(&self.hash_root, path, &self.config)?;
+                self.files.insert(path.clone(), result);
+            } else {
+                self.files.remove(path);
+            }
+        }
+        Ok(())
+    }
+
+    /// Swap in a new config and trigger a full rebuild.
+    pub fn update_config(&mut self, config: Config) -> anyhow::Result<()> {
+        self.hash_root = stylance_core::resolve_hash_root(&self.manifest_dir, &config);
+        self.config = config;
+        self.build_all()
+    }
+
+    /// Return the cached results after collision-checking and sorting.
+    pub fn output(&self) -> anyhow::Result<Vec<ModifyCssResult>> {
+        let mut results: Vec<ModifyCssResult> = self.files.values().cloned().collect();
+        check_hash_collisions(&results)?;
+        sort_results(&mut results);
+        Ok(results)
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    pub fn manifest_dir(&self) -> &Path {
+        &self.manifest_dir
+    }
 }
 
 #[cfg(test)]

--- a/stylance-cli/src/main.rs
+++ b/stylance-cli/src/main.rs
@@ -1,11 +1,14 @@
 use anyhow::bail;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
 };
-use stylance_cli::run;
+use stylance_cli::{
+    build_crate, build_output_file_content, write_output_dir, write_output_file, CrateBuilder,
+    ModifyCssResult,
+};
 use stylance_core::{load_config, Config};
 
 use clap::Parser;
@@ -48,21 +51,12 @@ struct RunParams {
     config: Config,
 }
 
-fn check_output_collisions(all_params: &[RunParams]) -> anyhow::Result<()> {
-    let mut seen_files: HashMap<PathBuf, &Path> = HashMap::new();
+/// Check that no two crates share the same output_dir (not supported).
+/// Shared output_file is allowed and handled by concatenation.
+fn check_output_dir_collisions(all_params: &[RunParams]) -> anyhow::Result<()> {
     let mut seen_dirs: HashMap<PathBuf, &Path> = HashMap::new();
 
     for params in all_params {
-        if let Some(output_file) = &params.config.output_file {
-            if let Some(prev) = seen_files.insert(output_file.clone(), &params.manifest_dir) {
-                bail!(
-                    "Multiple crates share the same output_file: {}\n  - {}\n  - {}",
-                    output_file.display(),
-                    prev.display(),
-                    params.manifest_dir.display(),
-                );
-            }
-        }
         if let Some(output_dir) = &params.config.output_dir {
             if let Some(prev) = seen_dirs.insert(output_dir.clone(), &params.manifest_dir) {
                 bail!(
@@ -72,6 +66,48 @@ fn check_output_collisions(all_params: &[RunParams]) -> anyhow::Result<()> {
                     params.manifest_dir.display(),
                 );
             }
+        }
+    }
+
+    Ok(())
+}
+
+/// Write all outputs, concatenating results for crates that share an output_file.
+/// Crate ordering follows CLI argument order.
+fn write_all_outputs(
+    all_params: &[RunParams],
+    all_results: &[Vec<ModifyCssResult>],
+) -> anyhow::Result<()> {
+    // Group crate indices by output_file path
+    let mut output_file_groups: HashMap<&Path, Vec<usize>> = HashMap::new();
+    for (i, params) in all_params.iter().enumerate() {
+        if let Some(output_file) = &params.config.output_file {
+            output_file_groups
+                .entry(output_file.as_path())
+                .or_default()
+                .push(i);
+        }
+    }
+
+    // Write each output_file group once
+    let mut written_files: HashSet<&Path> = HashSet::new();
+    for (output_file, group) in &output_file_groups {
+        if written_files.insert(output_file) {
+            let crate_results: Vec<&[ModifyCssResult]> =
+                group.iter().map(|&i| all_results[i].as_slice()).collect();
+            let scss_prelude = all_params[group[0]].config.scss_prelude.as_deref();
+            write_output_file(output_file, scss_prelude, &crate_results)?;
+        }
+    }
+
+    // Write output_dirs (per-crate, no sharing)
+    for (i, params) in all_params.iter().enumerate() {
+        if let Some(output_dir) = &params.config.output_dir {
+            write_output_dir(
+                output_dir,
+                params.config.scss_prelude.as_deref(),
+                &all_results[i],
+            )?;
         }
     }
 
@@ -88,27 +124,57 @@ async fn main() -> anyhow::Result<()> {
         all_params.push(params);
     }
 
-    check_output_collisions(&all_params)?;
+    check_output_dir_collisions(&all_params)?;
 
+    // Build all crates
+    let mut all_results: Vec<Vec<ModifyCssResult>> = Vec::new();
     for params in &all_params {
-        run(&params.manifest_dir, &params.config)?;
+        println!("Running stylance");
+        let results = build_crate(&params.manifest_dir, &params.config, |path| {
+            println!("{}", path.display());
+        })?;
+        all_results.push(results);
     }
+
+    // Write outputs with shared output_file support
+    write_all_outputs(&all_params, &all_results)?;
 
     if cli.watch {
         let cli = Arc::new(cli);
+        let (agg_tx, agg_rx) = mpsc::unbounded_channel();
 
-        // Spawn one independent watch task per manifest dir, as each crate
-        // has its own config, folders, and output.
+        // Initialize CrateBuilders from existing results (avoids re-reading files)
+        let builders: Vec<CrateBuilder> = all_params
+            .into_iter()
+            .zip(all_results)
+            .map(|(params, results)| {
+                CrateBuilder::from_results(params.manifest_dir, params.config, results)
+            })
+            .collect();
+
+        // Spawn aggregator
+        let agg_handle = tokio::spawn(run_aggregator(agg_rx));
+
+        // Spawn one watcher per crate
         let mut set = JoinSet::new();
-        for params in all_params {
+        for (i, builder) in builders.into_iter().enumerate() {
             let cli = cli.clone();
-            set.spawn(watch_single(cli, params));
+            let tx = agg_tx.clone();
+            set.spawn(watch_crate(cli, i, builder, tx));
         }
+        drop(agg_tx); // aggregator exits when all watchers drop their senders
 
         // If any watcher ends (only happens on error), abort the rest and exit.
-        if let Some(result) = set.join_next().await {
-            set.abort_all();
-            result??;
+        tokio::select! {
+            result = async { set.join_next().await } => {
+                if let Some(result) = result {
+                    set.abort_all();
+                    result??;
+                }
+            }
+            result = agg_handle => {
+                result??;
+            }
         }
     }
 
@@ -139,6 +205,84 @@ async fn make_run_params(cli: &Cli, manifest_dir: &Path) -> anyhow::Result<RunPa
     })
 }
 
+// ---------------------------------------------------------------------------
+// Aggregator: receives build results and writes combined outputs
+// ---------------------------------------------------------------------------
+
+struct CrateBuildResult {
+    crate_index: usize,
+    config: Config,
+    results: Vec<ModifyCssResult>,
+}
+
+async fn run_aggregator(mut rx: mpsc::UnboundedReceiver<CrateBuildResult>) -> anyhow::Result<()> {
+    let mut configs: HashMap<usize, Config> = HashMap::new();
+    let mut results: HashMap<usize, Vec<ModifyCssResult>> = HashMap::new();
+    let mut last_written: HashMap<PathBuf, String> = HashMap::new();
+
+    while let Some(msg) = rx.recv().await {
+        configs.insert(msg.crate_index, msg.config);
+        results.insert(msg.crate_index, msg.results);
+        println!("Running stylance");
+
+        // Group crate indices by output_file
+        let mut output_file_groups: HashMap<&Path, Vec<usize>> = HashMap::new();
+        for (&i, config) in &configs {
+            if let Some(output_file) = &config.output_file {
+                output_file_groups
+                    .entry(output_file.as_path())
+                    .or_default()
+                    .push(i);
+            }
+        }
+
+        // Ensure stable ordering within each group
+        for group in output_file_groups.values_mut() {
+            group.sort();
+        }
+
+        // Write each output_file group (content-aware: skip if unchanged)
+        for (output_file, group) in &output_file_groups {
+            let crate_results: Vec<&[ModifyCssResult]> = group
+                .iter()
+                .map(|i| results.get(i).map(|r| r.as_slice()).unwrap_or(&[]))
+                .collect();
+            let scss_prelude = configs[&group[0]].scss_prelude.as_deref();
+
+            let new_content = build_output_file_content(output_file, scss_prelude, &crate_results);
+
+            if last_written.get(*output_file) != Some(&new_content) {
+                if let Err(e) = write_output_file(output_file, scss_prelude, &crate_results) {
+                    eprintln!("{e}");
+                } else {
+                    last_written.insert(output_file.to_path_buf(), new_content);
+                }
+            }
+        }
+
+        // Write output_dirs (per-crate, no sharing)
+        if let Some(config) = configs.get(&msg.crate_index) {
+            if let Some(output_dir) = &config.output_dir {
+                let crate_results = results
+                    .get(&msg.crate_index)
+                    .map(|r| r.as_slice())
+                    .unwrap_or(&[]);
+                if let Err(e) =
+                    write_output_dir(output_dir, config.scss_prelude.as_deref(), crate_results)
+                {
+                    eprintln!("{e}");
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// File watching helpers
+// ---------------------------------------------------------------------------
+
 fn watch_file(path: &Path) -> anyhow::Result<mpsc::UnboundedReceiver<()>> {
     let (events_tx, events_rx) = mpsc::unbounded_channel();
     let mut watcher = notify::recommended_watcher({
@@ -167,7 +311,7 @@ fn watch_file(path: &Path) -> anyhow::Result<mpsc::UnboundedReceiver<()>> {
     Ok(events_rx)
 }
 
-fn watch_folders(paths: &Vec<PathBuf>) -> anyhow::Result<mpsc::UnboundedReceiver<PathBuf>> {
+fn watch_folders(paths: &[PathBuf]) -> anyhow::Result<mpsc::UnboundedReceiver<PathBuf>> {
     let (events_tx, events_rx) = mpsc::unbounded_channel();
     let mut watcher = notify::recommended_watcher({
         let events_tx = events_tx.clone();
@@ -214,87 +358,133 @@ async fn debounced_next(s: &mut (impl Stream<Item = ()> + Unpin)) -> Option<()> 
     }
 }
 
-/// Watch a single manifest dir independently. Each crate gets its own
-/// watcher, config reload, and run loop — a change in one crate only
-/// triggers a rebuild for that crate.
-async fn watch_single(cli: Arc<Cli>, run_params: RunParams) -> anyhow::Result<()> {
-    let manifest_dir = run_params.manifest_dir.clone();
-    let (run_params_tx, mut run_params) = tokio::sync::watch::channel(Arc::new(run_params));
+/// Collect changed file paths during a debounce window, filtering by extension.
+async fn debounced_collect(
+    rx: &mut mpsc::UnboundedReceiver<PathBuf>,
+    extensions: &[String],
+) -> Option<HashSet<PathBuf>> {
+    let mut paths = HashSet::new();
 
-    // Watch Cargo.toml to update the current run_params.
+    // Wait for first matching event
+    loop {
+        let path = rx.recv().await?;
+        let str_path = path.to_string_lossy();
+        if extensions.iter().any(|ext| str_path.ends_with(ext)) {
+            paths.insert(path);
+            break;
+        }
+    }
+
+    // Collect during debounce window
+    loop {
+        match tokio::time::timeout(Duration::from_millis(50), rx.recv()).await {
+            Ok(Some(path)) => {
+                let str_path = path.to_string_lossy();
+                if extensions.iter().any(|ext| str_path.ends_with(ext)) {
+                    paths.insert(path);
+                }
+            }
+            Ok(None) => return None,
+            Err(_) => return Some(paths),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-crate watch loop with incremental rebuilds
+// ---------------------------------------------------------------------------
+
+async fn watch_crate(
+    cli: Arc<Cli>,
+    crate_index: usize,
+    mut builder: CrateBuilder,
+    output_tx: mpsc::UnboundedSender<CrateBuildResult>,
+) -> anyhow::Result<()> {
+    let manifest_dir = builder.manifest_dir().to_path_buf();
+
+    // Watch Cargo.toml for config changes
     let cargo_toml_events = watch_file(&manifest_dir.join("Cargo.toml").canonicalize()?)?;
+    let (config_tx, mut config_rx) = mpsc::channel::<Config>(1);
     let manifest_dir_clone = manifest_dir.clone();
     tokio::spawn(async move {
         let mut stream = tokio_stream::wrappers::UnboundedReceiverStream::new(cargo_toml_events);
         while debounced_next(&mut stream).await.is_some() {
             match make_run_params(&cli, &manifest_dir_clone).await {
                 Ok(new_params) => {
-                    if run_params_tx.send(Arc::new(new_params)).is_err() {
+                    if config_tx.send(new_params.config).await.is_err() {
                         return;
-                    };
+                    }
                 }
-                Err(e) => {
-                    eprintln!("{e}");
-                }
-            }
-        }
-    });
-
-    // Wait for run_events to run the stylance process.
-    let (run_events_tx, run_events) = mpsc::channel(1);
-    tokio::spawn({
-        let run_params = run_params.clone();
-        async move {
-            let mut stream = tokio_stream::wrappers::ReceiverStream::new(run_events);
-            while (debounced_next(&mut stream).await).is_some() {
-                let run_params = run_params.borrow().clone();
-                if let Ok(Err(e)) =
-                    spawn_blocking(move || run(&run_params.manifest_dir, &run_params.config)).await
-                {
-                    eprintln!("{e}");
-                }
+                Err(e) => eprintln!("{e}"),
             }
         }
     });
 
     loop {
-        // Watch the folders from the current run_params
-        let mut events = watch_folders(
-            &run_params
-                .borrow()
-                .config
-                .folders()
-                .iter()
-                .map(|f| manifest_dir.join(f))
-                .collect(),
-        )?;
+        // Watch folders with current config
+        let folder_paths: Vec<PathBuf> = builder
+            .config()
+            .folders()
+            .iter()
+            .map(|f| manifest_dir.join(f))
+            .collect();
+        let mut folder_events = watch_folders(&folder_paths)?;
 
-        // With the events from the watched folder trigger run_events if they match the extensions of the config.
-        let watch_folders = {
-            let run_params = run_params.borrow().clone();
-            let run_events_tx = run_events_tx.clone();
-            async move {
-                while let Some(path) = events.recv().await {
-                    let str_path = path.to_string_lossy();
-                    if run_params
-                        .config
-                        .extensions()
-                        .iter()
-                        .any(|ext| str_path.ends_with(ext))
-                    {
-                        let _ = run_events_tx.try_send(());
-                        break;
-                    }
+        let extensions: Vec<String> = builder.config().extensions().to_vec();
+
+        // Wait for either file changes or config changes
+        enum WatchEvent {
+            FilesChanged(HashSet<PathBuf>),
+            ConfigChanged(Config),
+        }
+
+        let event = tokio::select! {
+            changed = debounced_collect(&mut folder_events, &extensions) => {
+                match changed {
+                    Some(paths) => WatchEvent::FilesChanged(paths),
+                    None => return Ok(()),
+                }
+            }
+            config = config_rx.recv() => {
+                match config {
+                    Some(config) => WatchEvent::ConfigChanged(config),
+                    None => return Ok(()),
                 }
             }
         };
 
-        // Run until the config has changed
-        tokio::select! {
-            _ = watch_folders => {},
-            _ = run_params.changed() => {
-                let _ = run_events_tx.try_send(()); // Config changed so lets trigger a run
-            },
+        // Run the rebuild in a blocking task (returns builder even on error)
+        let (b, result) = match event {
+            WatchEvent::FilesChanged(changed) => {
+                spawn_blocking(move || {
+                    let rebuild = builder
+                        .rebuild_changed(&changed)
+                        .and_then(|()| builder.output());
+                    (builder, rebuild)
+                })
+                .await?
+            }
+            WatchEvent::ConfigChanged(config) => {
+                spawn_blocking(move || {
+                    let rebuild = builder
+                        .update_config(config)
+                        .and_then(|()| builder.output());
+                    (builder, rebuild)
+                })
+                .await?
+            }
+        };
+        builder = b;
+
+        match result {
+            Ok(results) => {
+                let _ = output_tx.send(CrateBuildResult {
+                    crate_index,
+                    config: builder.config().clone(),
+                    results,
+                });
+            }
+            Err(e) => eprintln!("{e}"),
         }
     }
 }

--- a/stylance-cli/tests/test_multiple_dirs.rs
+++ b/stylance-cli/tests/test_multiple_dirs.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
-use stylance_cli::{run_silent, Config};
+use stylance_cli::{
+    build_crate, build_output_file_content, run_silent, write_output_file, Config, CrateBuilder,
+};
 use stylance_core::load_config;
 
 fn fixtures_dir() -> PathBuf {
@@ -558,4 +560,340 @@ folders = ["nonexistent_folder"]
     }
 
     let _ = std::fs::remove_dir_all(&tmpdir);
+}
+
+// ---------------------------------------------------------------------------
+// Shared output_file tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_shared_output_file_concatenates_css() {
+    let crate1 = fixtures_dir().join("crate1");
+    let crate2 = fixtures_dir().join("crate2");
+
+    let tmpdir = std::env::temp_dir().join("stylance_test_shared_output");
+    let _ = std::fs::remove_dir_all(&tmpdir);
+    std::fs::create_dir_all(&tmpdir).unwrap();
+
+    let shared_output = tmpdir.join("bundle.css");
+
+    let mut config1 = load_config(&crate1).unwrap();
+    config1.output_file = Some(shared_output.clone());
+
+    let mut config2 = load_config(&crate2).unwrap();
+    config2.output_file = Some(shared_output.clone());
+
+    let results1 = build_crate(&crate1, &config1, |_| {}).unwrap();
+    let results2 = build_crate(&crate2, &config2, |_| {}).unwrap();
+
+    write_output_file(
+        &shared_output,
+        None,
+        &[results1.as_slice(), results2.as_slice()],
+    )
+    .unwrap();
+
+    let content = std::fs::read_to_string(&shared_output).unwrap();
+
+    // Both crates' CSS should be present
+    assert!(
+        content.contains("container-"),
+        "should contain crate1 class"
+    );
+    assert!(content.contains("title-"), "should contain crate1 class");
+    assert!(content.contains("wrapper-"), "should contain crate2 class");
+    assert!(content.contains("header-"), "should contain crate2 class");
+
+    let _ = std::fs::remove_dir_all(&tmpdir);
+}
+
+#[test]
+fn test_shared_output_file_preserves_crate_order() {
+    let crate1 = fixtures_dir().join("crate1");
+    let crate2 = fixtures_dir().join("crate2");
+
+    let mut config1 = load_config(&crate1).unwrap();
+    config1.output_file = Some(PathBuf::from("dummy.css"));
+
+    let mut config2 = load_config(&crate2).unwrap();
+    config2.output_file = Some(PathBuf::from("dummy.css"));
+
+    let results1 = build_crate(&crate1, &config1, |_| {}).unwrap();
+    let results2 = build_crate(&crate2, &config2, |_| {}).unwrap();
+
+    // Order: crate1 first, then crate2
+    let content_1_2 = build_output_file_content(
+        Path::new("dummy.css"),
+        None,
+        &[results1.as_slice(), results2.as_slice()],
+    );
+
+    // Order: crate2 first, then crate1
+    let content_2_1 = build_output_file_content(
+        Path::new("dummy.css"),
+        None,
+        &[results2.as_slice(), results1.as_slice()],
+    );
+
+    // Both orderings should contain all classes
+    assert!(content_1_2.contains("container-"));
+    assert!(content_1_2.contains("wrapper-"));
+
+    // But the order of CSS blocks should differ
+    let pos_container_1_2 = content_1_2.find("container-").unwrap();
+    let pos_wrapper_1_2 = content_1_2.find("wrapper-").unwrap();
+    assert!(
+        pos_container_1_2 < pos_wrapper_1_2,
+        "crate1 CSS should come before crate2 CSS"
+    );
+
+    let pos_container_2_1 = content_2_1.find("container-").unwrap();
+    let pos_wrapper_2_1 = content_2_1.find("wrapper-").unwrap();
+    assert!(
+        pos_wrapper_2_1 < pos_container_2_1,
+        "reversed order: crate2 CSS should come before crate1 CSS"
+    );
+}
+
+#[test]
+fn test_shared_output_file_via_cli() {
+    let binary = env!("CARGO_BIN_EXE_stylance");
+    let crate1 = fixtures_dir().join("crate1");
+    let crate2 = fixtures_dir().join("crate2");
+
+    let tmpdir = std::env::temp_dir().join("stylance_test_shared_cli");
+    let _ = std::fs::remove_dir_all(&tmpdir);
+    std::fs::create_dir_all(&tmpdir).unwrap();
+
+    let shared_output = tmpdir.join("shared.css");
+
+    let output = std::process::Command::new(binary)
+        .arg(&crate1)
+        .arg(&crate2)
+        .arg("--output-file")
+        .arg(&shared_output)
+        .output()
+        .expect("failed to execute stylance binary");
+
+    assert!(
+        output.status.success(),
+        "stylance with shared --output-file failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let content = std::fs::read_to_string(&shared_output).unwrap();
+    assert!(
+        content.contains("container-"),
+        "shared output should contain crate1 CSS"
+    );
+    assert!(
+        content.contains("wrapper-"),
+        "shared output should contain crate2 CSS"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmpdir);
+}
+
+#[test]
+fn test_shared_output_no_longer_errors() {
+    // Previously, two crates sharing output_file would error.
+    // Now it should succeed via concatenation.
+    let binary = env!("CARGO_BIN_EXE_stylance");
+    let crate1 = fixtures_dir().join("crate1");
+    let crate2 = fixtures_dir().join("crate2");
+
+    // Both fixture crates have output_file = "output.css" in their Cargo.toml.
+    // With the old code this would error; now it should concatenate.
+    let output = std::process::Command::new(binary)
+        .arg(&crate1)
+        .arg(&crate2)
+        .output()
+        .expect("failed to execute stylance binary");
+
+    assert!(
+        output.status.success(),
+        "shared output_file should no longer error: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CrateBuilder tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_crate_builder_build_all() {
+    let crate1 = fixtures_dir().join("crate1");
+    let config = load_config(&crate1).unwrap();
+
+    let mut builder = CrateBuilder::new(crate1, config);
+    builder.build_all().unwrap();
+
+    let output = builder.output().unwrap();
+    assert_eq!(output.len(), 1);
+    assert!(output[0].contents.contains("container-"));
+}
+
+#[test]
+fn test_crate_builder_incremental_rebuild() {
+    let tmpdir = std::env::temp_dir().join("stylance_test_incremental");
+    let _ = std::fs::remove_dir_all(&tmpdir);
+    std::fs::create_dir_all(tmpdir.join("src")).unwrap();
+
+    std::fs::write(tmpdir.join("src/a.module.css"), ".alpha { color: red; }").unwrap();
+    std::fs::write(tmpdir.join("src/b.module.css"), ".beta { color: blue; }").unwrap();
+
+    let config = Config {
+        output_file: Some(tmpdir.join("out.css")),
+        ..Config::default()
+    };
+
+    let mut builder = CrateBuilder::new(tmpdir.clone(), config);
+    builder.build_all().unwrap();
+
+    let output = builder.output().unwrap();
+    assert_eq!(output.len(), 2);
+
+    // Modify one file
+    std::fs::write(tmpdir.join("src/a.module.css"), ".alpha { color: green; }").unwrap();
+
+    let mut changed = std::collections::HashSet::new();
+    changed.insert(tmpdir.join("src/a.module.css"));
+    builder.rebuild_changed(&changed).unwrap();
+
+    let output = builder.output().unwrap();
+    assert_eq!(output.len(), 2);
+
+    // The changed file should have the new content
+    let alpha_result = output
+        .iter()
+        .find(|r| r.contents.contains("alpha-"))
+        .unwrap();
+    assert!(alpha_result.contents.contains("color: green"));
+
+    // The unchanged file should still be present
+    let beta_result = output
+        .iter()
+        .find(|r| r.contents.contains("beta-"))
+        .unwrap();
+    assert!(beta_result.contents.contains("color: blue"));
+
+    let _ = std::fs::remove_dir_all(&tmpdir);
+}
+
+#[test]
+fn test_crate_builder_incremental_delete() {
+    let tmpdir = std::env::temp_dir().join("stylance_test_incr_delete");
+    let _ = std::fs::remove_dir_all(&tmpdir);
+    std::fs::create_dir_all(tmpdir.join("src")).unwrap();
+
+    std::fs::write(tmpdir.join("src/a.module.css"), ".alpha { color: red; }").unwrap();
+    std::fs::write(tmpdir.join("src/b.module.css"), ".beta { color: blue; }").unwrap();
+
+    let config = Config::default();
+    let mut builder = CrateBuilder::new(tmpdir.clone(), config);
+    builder.build_all().unwrap();
+    assert_eq!(builder.output().unwrap().len(), 2);
+
+    // Delete one file
+    std::fs::remove_file(tmpdir.join("src/b.module.css")).unwrap();
+
+    let mut changed = std::collections::HashSet::new();
+    changed.insert(tmpdir.join("src/b.module.css"));
+    builder.rebuild_changed(&changed).unwrap();
+
+    let output = builder.output().unwrap();
+    assert_eq!(output.len(), 1);
+    assert!(output[0].contents.contains("alpha-"));
+
+    let _ = std::fs::remove_dir_all(&tmpdir);
+}
+
+#[test]
+fn test_crate_builder_incremental_create() {
+    let tmpdir = std::env::temp_dir().join("stylance_test_incr_create");
+    let _ = std::fs::remove_dir_all(&tmpdir);
+    std::fs::create_dir_all(tmpdir.join("src")).unwrap();
+
+    std::fs::write(tmpdir.join("src/a.module.css"), ".alpha { color: red; }").unwrap();
+
+    let config = Config::default();
+    let mut builder = CrateBuilder::new(tmpdir.clone(), config);
+    builder.build_all().unwrap();
+    assert_eq!(builder.output().unwrap().len(), 1);
+
+    // Create a new file
+    std::fs::write(tmpdir.join("src/b.module.css"), ".beta { color: blue; }").unwrap();
+
+    let mut changed = std::collections::HashSet::new();
+    changed.insert(tmpdir.join("src/b.module.css"));
+    builder.rebuild_changed(&changed).unwrap();
+
+    let output = builder.output().unwrap();
+    assert_eq!(output.len(), 2);
+
+    let _ = std::fs::remove_dir_all(&tmpdir);
+}
+
+#[test]
+fn test_crate_builder_update_config() {
+    let tmpdir = std::env::temp_dir().join("stylance_test_config_update");
+    let _ = std::fs::remove_dir_all(&tmpdir);
+    std::fs::create_dir_all(tmpdir.join("src")).unwrap();
+
+    std::fs::write(tmpdir.join("src/a.module.css"), ".alpha { color: red; }").unwrap();
+
+    let config = Config {
+        hash_len: Some(5),
+        ..Config::default()
+    };
+    let mut builder = CrateBuilder::new(tmpdir.clone(), config);
+    builder.build_all().unwrap();
+
+    let output_before = builder.output().unwrap();
+    let hash_before = &output_before[0].hash;
+    assert_eq!(hash_before.len(), 5);
+
+    // Update config with different hash_len
+    let new_config = Config {
+        hash_len: Some(10),
+        ..Config::default()
+    };
+    builder.update_config(new_config).unwrap();
+
+    let output_after = builder.output().unwrap();
+    let hash_after = &output_after[0].hash;
+    assert_eq!(hash_after.len(), 10);
+
+    let _ = std::fs::remove_dir_all(&tmpdir);
+}
+
+#[test]
+fn test_crate_builder_from_results() {
+    let crate1 = fixtures_dir().join("crate1");
+    let config = load_config(&crate1).unwrap();
+
+    let results = build_crate(&crate1, &config, |_| {}).unwrap();
+    let builder = CrateBuilder::from_results(crate1, config, results);
+
+    let output = builder.output().unwrap();
+    assert_eq!(output.len(), 1);
+    assert!(output[0].contents.contains("container-"));
+}
+
+// ---------------------------------------------------------------------------
+// Content-aware output writing test
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_content_aware_build_output() {
+    let crate1 = fixtures_dir().join("crate1");
+    let config = load_config(&crate1).unwrap();
+    let results = build_crate(&crate1, &config, |_| {}).unwrap();
+
+    let content1 = build_output_file_content(Path::new("output.css"), None, &[results.as_slice()]);
+    let content2 = build_output_file_content(Path::new("output.css"), None, &[results.as_slice()]);
+
+    // Same inputs should produce identical content
+    assert_eq!(content1, content2);
 }


### PR DESCRIPTION
When multiple crates resolve to the same output_file, stylance now concatenates their processed CSS into that file instead of erroring. Crate ordering follows CLI argument order with per-crate internal sorting preserved.

Watch mode now uses a CrateBuilder with per-file caching so that only changed files are re-read and re-parsed. An aggregator task receives per-crate build results and writes combined outputs. Content-aware output writing skips disk writes when the output hasn't changed.

Closes #35